### PR TITLE
24 modulenotfounderror no module named django api mixinsfilter backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,4 +581,4 @@ pip install django-api-mixins
 
 **PyPI Project Page**: [https://pypi.org/project/django-api-mixins/](https://pypi.org/project/django-api-mixins/)
 
-**Latest Version**: 2.0.0 (Released: May 23, 2026)
+**Latest Version**: 2.0.1 (Released: June 16, 2026)

--- a/django_api_mixins/__init__.py
+++ b/django_api_mixins/__init__.py
@@ -3,7 +3,7 @@ Django REST Framework API Mixins
 
 A collection of useful mixins for Django REST Framework ViewSets and APIViews.
 """
-from .filter_backends import NotInFilterBackend
+from .filter_backends.not_in import NotInFilterBackend
 from .mixins import (
     APIMixin,
     ModelMixin,
@@ -14,7 +14,7 @@ from .mixins import (
 )
 from .lookups import FieldLookup
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __all__ = [
     "APIMixin",
     "ModelMixin",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-api-mixins"
-version = "2.0.0"
+version = "2.0.1"
 description = "Django REST Framework mixins for ViewSets and APIViews - APIMixin, ModelMixin, RelationshipFilterMixin, RoleBasedFilterMixin. Simplify Django API development with reusable mixins."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
:bug: fixed import issue
ModuleNotFoundError: No module named 'django_api_mixins.filter_backends'