### PR TITLE
:bug: fixed import issue ModuleNotFoundError: No module named 'django_api_mixins.filter_backends'

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.md
 include LICENSE
 include pyproject.toml
-recursive-include src *.py
+recursive-include django_api_mixins *.py

--- a/README.md
+++ b/README.md
@@ -581,4 +581,4 @@ pip install django-api-mixins
 
 **PyPI Project Page**: [https://pypi.org/project/django-api-mixins/](https://pypi.org/project/django-api-mixins/)
 
-**Latest Version**: 2.0.1 (Released: June 16, 2026)
+**Latest Version**: 2.0.2 (Released: June 16, 2026)

--- a/django_api_mixins/__init__.py
+++ b/django_api_mixins/__init__.py
@@ -14,7 +14,7 @@ from .mixins import (
 )
 from .lookups import FieldLookup
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 __all__ = [
     "APIMixin",
     "ModelMixin",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-api-mixins"
-version = "2.0.1"
+version = "2.0.2"
 description = "Django REST Framework mixins for ViewSets and APIViews - APIMixin, ModelMixin, RelationshipFilterMixin, RoleBasedFilterMixin. Simplify Django API development with reusable mixins."
 readme = "README.md"
 requires-python = ">=3.8"
@@ -73,7 +73,7 @@ Repository = "https://github.com/Subhrans/django-api-mixins"
 Issues = "https://github.com/subhrans/django-api-mixins/issues"
 
 [tool.setuptools]
-packages = ["django_api_mixins"]
+packages = ["django_api_mixins", "django_api_mixins.filter_backends"]
 # Avoid License-File in METADATA (PEP 639); PyPI/twine may reject it. We use license = {text = "MIT"} instead.
 license-files = []
 


### PR DESCRIPTION
:bug: fixed import issue
ModuleNotFoundError: No module named 'django_api_mixins.filter_backends'